### PR TITLE
Fix Quepaso

### DIFF
--- a/commands/summary.py
+++ b/commands/summary.py
@@ -4,7 +4,12 @@ import math
 import feedparser
 import urllib
 
-from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, CallbackQuery
+from telegram import (
+    Update,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    CallbackQuery,
+)
 from telegram.ext import CallbackContext
 
 from ai.provider import ai_client
@@ -86,9 +91,9 @@ def resumir(update: Update, context: CallbackContext) -> None:
             alias_dict = get_alias_dict_from_string(
                 update.message.reply_to_message.text
             )
-            prompt_text = anonymize([update.message.reply_to_message.text], alias_dict)[
-                0
-            ]
+            prompt_text = anonymize(
+                [update.message.reply_to_message.text], alias_dict
+            )[0]
             response = client.generate(
                 system=PROMPT_SYSTEM_MESSAGE_SINGLE,
                 conversation=[GenAIMessage("user", prompt_text)],
@@ -167,7 +172,9 @@ def resumir(update: Update, context: CallbackContext) -> None:
             },
         ]
 
-        input_tokens = num_tokens_from_string(str(prompt_messages), RESUMIR_MODEL)
+        input_tokens = num_tokens_from_string(
+            str(prompt_messages), RESUMIR_MODEL
+        )
         # Based on real usage data
         expected_output_tokens = -300 + 86.8 * math.log(input_tokens + 31.697)
 
@@ -187,7 +194,8 @@ def resumir(update: Update, context: CallbackContext) -> None:
                             ),
                         ),
                         InlineKeyboardButton(
-                            "Cancelar", callback_data=json.dumps(["cancel_summary"])
+                            "Cancelar",
+                            callback_data=json.dumps(["cancel_summary"]),
                         ),
                     ],
                 ]
@@ -225,7 +233,9 @@ def _do_resumir(query: CallbackQuery, context: CallbackContext) -> None:
         alias_dict = get_alias_dict_from_messages_list(input_messages)
         input_messages = anonymize(input_messages, alias_dict)
 
-        input_tokens = num_tokens_from_string(str(input_messages), RESUMIR_MODEL)
+        input_tokens = num_tokens_from_string(
+            str(input_messages), RESUMIR_MODEL
+        )
 
         response = client.generate(
             system=PROMPT_SYSTEM_MESSAGE_MULTIPLE,
@@ -283,7 +293,9 @@ def button(update: Update, context: CallbackContext) -> None:
             )
             _do_resumir(query, context)
         elif query_data[0] == "cancel_summary":
-            query.edit_message_text(text=f"{query.message.text}\n\nResumen cancelado.")
+            query.edit_message_text(
+                text=f"{query.message.text}\n\nResumen cancelado."
+            )
 
 
 @member_exclusive
@@ -297,10 +309,9 @@ def noticia(update: Update, context: CallbackContext) -> None:
             return
 
         q = urllib.parse.quote_plus(arg)
-        url = f'https://news.google.com/rss/search?hl=es-419&gl=CL&ceid=CL:es-419&q={q}'
+        url = f"https://news.google.com/rss/search?hl=es-419&gl=CL&ceid=CL:es-419&q={q}"
         rss = feedparser.parse(url)
         titles = [article.title for article in rss.entries]
-
 
         PROMPT_NEWS_HEADLINES = (
             "Eres un bot para resumir titulares de noticias. "
@@ -315,7 +326,9 @@ def noticia(update: Update, context: CallbackContext) -> None:
             conversation=[GenAIMessage("user", "\n".join(titles))],
         )
 
-        message = result.message + "\n\n" + f"⛲️ <a href='{url}'>Google News</a>"
+        message = (
+            result.message + "\n\n" + f"⛲️ <a href='{url}'>Google News</a>"
+        )
 
         try_msg(
             context.bot,

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ dnspython==1.16.0
 feedparser==6.0.11
 filelock==3.15.4
 fsspec==2024.6.1
-gnews==0.3.7
 h11==0.14.0
 httpcore==1.0.5
 httpx==0.27.0
@@ -22,7 +21,6 @@ idna==3.7
 joblib==1.4.2
 lxml==5.2.2
 lxml_html_clean==0.1.1
-newspaper4k==0.9.3
 nltk==3.8.1
 numpy==2.0.0
 openai==1.35.1


### PR DESCRIPTION
Idea y 99% de la implementación fue por @scisneros realmente, yo solo lo ejecuté.

Cambia el `/quepaso` de usar newspaper4k y gnews a leer directo del feed RSS de google news, así evitando el problema que teníamos con que se crasheaba newspaper4k por el cambio en el sistema de URLs de google news.