### PR TITLE
Fix: Parsing de quepaso

### DIFF
--- a/commands/summary.py
+++ b/commands/summary.py
@@ -332,7 +332,22 @@ def noticia(update: Update, context: CallbackContext, command: Command) -> None:
     q = urllib.parse.quote_plus(cmd.arg)
     url = f"https://news.google.com/rss/search?hl=es-419&gl=CL&ceid=CL:es-419&q={q}"
     rss = feedparser.parse(url)
-    titles = [article.title for article in rss.entries][:10]
+
+    def parse_entries(entries):
+        titles = []
+        for entry in entries:
+            if "<ol><li>" in entry.description:
+                regex = r"<a href=\"(?:.*?)\">(.*?)<\/a>"
+                matches = re.findall(
+                    regex,
+                    entry.description.replace("\n", ""),
+                )
+                titles.extend(matches)
+            else:
+                titles.append(entry.title)
+        return titles
+
+    titles = parse_entries(rss.entries)[:10]
 
     PROMPT_NEWS_HEADLINES = (
         "Eres un bot para resumir titulares de noticias. "

--- a/commands/summary.py
+++ b/commands/summary.py
@@ -332,7 +332,7 @@ def noticia(update: Update, context: CallbackContext, command: Command) -> None:
     q = urllib.parse.quote_plus(cmd.arg)
     url = f"https://news.google.com/rss/search?hl=es-419&gl=CL&ceid=CL:es-419&q={q}"
     rss = feedparser.parse(url)
-    titles = [article.title for article in rss.entries]
+    titles = [article.title for article in rss.entries][:10]
 
     PROMPT_NEWS_HEADLINES = (
         "Eres un bot para resumir titulares de noticias. "

--- a/commands/summary.py
+++ b/commands/summary.py
@@ -337,9 +337,9 @@ def noticia(update: Update, context: CallbackContext, command: Command) -> None:
         titles = []
         for entry in entries:
             if "<ol><li>" in entry.description:
-                regex = r"<a href=\"(?:.*?)\">(.*?)<\/a>"
+                headline_regex = r"<a href=\".*?\">(.*?)<\/a>"
                 matches = re.findall(
-                    regex,
+                    headline_regex,
                     entry.description.replace("\n", ""),
                 )
                 titles.extend(matches)


### PR DESCRIPTION
- Se limitan los titulares leídos a 10, para evitar leer noticias poco relacionadas.
- Cuando Google News agrupa varias noticias en un mismo tema, el RSS entrega todos los titulares agrupados dentro de la `description` en un mismo `item`. Este PR agrega detectar estas listas y parsear cada item interno.
Ejemplo:
```rss
<item>
  <title>Metro suspende el servicio en toda la Línea 3 por "falla técnica": Pasajeros son evacuados - EMOL</title>
  <link>https://...</link>
  <guid isPermaLink="false">CBMim...</guid>
  <pubDate>Thu, 08 Aug 2024 22:30:00 GMT</pubDate>
  <description>
    <ol>
      <li>
        <a href=...>Metro suspende el servicio en toda la Línea 3 por "falla técnica": Pasajeros son evacuados</a>&nbsp;&nbsp;<font color="#6f6f6f">EMOL</font>
      </li>
      <li>
        <a href=...>Suspenden servicio en toda la Línea 3 del Metro: solicitaron a pasajeros evacuar</a>&nbsp;&nbsp;<font color="#6f6f6f">T13.cl</font>
      </li>
      <li>
        <a href=...>FOTOS – Metro suspende servicio de Línea 3 por falla técnica</a>&nbsp;&nbsp;<font color="#6f6f6f">El Dínamo</font>
      </li>
    </ol> 
  </description>
  <source url="https://www.emol.com">EMOL</source>
</item>
```