### PR TITLE
Pasar reply como contexto a /gpt

### DIFF
--- a/commands/base.py
+++ b/commands/base.py
@@ -59,9 +59,9 @@ class Command:
         opts_dict = dict(opts_pairs)
         return opts_dict
 
-    def get_arg_reply(self) -> str:
+    def get_reply_or_arg(self) -> str:
         """
-        Returns the argument of a command or the text of a reply.
+        Returns the text of the message replied to OR the argument of the command.
         (Preference towards replies)
         """
         if self.message_obj.reply_to_message:
@@ -94,5 +94,5 @@ class CallbackQueryCommand(Command):
     def _parse_opts(self, opts):
         return json.loads(opts) if opts else {}
 
-    def get_arg_reply(self) -> str:
+    def get_reply_or_arg(self) -> str:
         pass

--- a/commands/base.py
+++ b/commands/base.py
@@ -68,6 +68,14 @@ class Command:
             return self.message_obj.reply_to_message.text
         return self.arg
 
+    def get_arg_and_reply(self) -> tuple[str, str]:
+        """
+        Returns the argument of a command AND the text of the message replied to.
+        """
+        if self.message_obj.reply_to_message:
+            return self.arg, self.message_obj.reply_to_message.text
+        return self.arg, ""
+
     def use_default_opt(self, default_key: str):
         """
         If only a single flag option is provided, assume it's the default key.

--- a/commands/gpt.py
+++ b/commands/gpt.py
@@ -29,7 +29,7 @@ def reply_fill(update: Update, context: CallbackContext, cmd: Command) -> None:
     client = ai_client(ai_model, update)
 
     cmd.use_default_opt("prompt")
-    message = cmd.get_arg_reply()
+    message = cmd.get_reply_or_arg()
     reply_message_id = update.message.message_id
 
     conversation = [
@@ -78,7 +78,7 @@ def reply_gpt(update: Update, context: CallbackContext, cmd: Command) -> None:
     ai_model = cmd.opts.pop("m", None) or cmd.opts.pop("model", None) or REPLY_MODEL
     client = ai_client(ai_model, update)
 
-    message = cmd.get_arg_reply()
+    message = cmd.get_reply_or_arg()
     reply_message_id = update.message.message_id
 
     conversation = [GenAIMessage("user", message)]
@@ -100,7 +100,7 @@ def desigliar(update: Update, context: CallbackContext, cmd: Command) -> None:
     Attempts to invent the words for a given acronym using an LLM
     """
     cmd.use_default_opt("prompt")
-    message = cmd.get_arg_reply()
+    message = cmd.get_reply_or_arg()
     reply_message_id = update.message.message_id
 
     ai_model = cmd.opts.pop("m", None) or cmd.opts.pop("model", None) or DESIGLIAR_MODEL

--- a/commands/gpt.py
+++ b/commands/gpt.py
@@ -78,12 +78,21 @@ def reply_gpt(update: Update, context: CallbackContext, cmd: Command) -> None:
     ai_model = cmd.opts.pop("m", None) or cmd.opts.pop("model", None) or REPLY_MODEL
     client = ai_client(ai_model, update)
 
-    message = cmd.get_reply_or_arg()
+    message, reply = cmd.get_arg_and_reply()
     reply_message_id = update.message.message_id
 
+    if reply:
+        system = (
+            f"Considera que el usuario está respondiendo a un mensaje. "
+            f"Este mensaje podría ser el sujeto del mensaje que te envía, un complemento, contexto adicional para el prompt, etc. "
+            f"El mensaje al que se está respondiendo es el siguiente:\n\n\"{reply}\""
+        )
+    else:
+        system = ""
+    
     conversation = [GenAIMessage("user", message)]
 
-    response = client.generate(conversation, **{"temperature": 0.5, **cmd.opts})
+    response = client.generate(conversation, system=system, **{"temperature": 0.5, **cmd.opts})
 
     try_msg(
         context.bot,

--- a/utils.py
+++ b/utils.py
@@ -140,7 +140,7 @@ def get_arg_reply(update: Update) -> str:
     Returns the argument of a command or the text of a reply.
     (Preference towards replies)
 
-    DEPRECATED: Use Command.get_arg_reply instead.
+    DEPRECATED: Use Command.get_reply_or_arg() instead.
     """
     if update.message.reply_to_message is None:
         return get_arg(update)


### PR DESCRIPTION
## Feature
Si `/gpt` se usa como reply a un mensaje, se agrega ese mensaje como contexto en el system prompt.

## Cambios
- Se agrega `get_arg_and_reply()`, que retorna el argumento del mensaje y el texto del reply, si existe.
- Se renombra `get_arg_reply()` a `get_reply_or_arg()`, para hacerla más descriptiva y diferenciarla de la otra función.
- Si hay reply, `reply_gpt()` agrega el texto e instrucciones apropiadas en el system prompt.